### PR TITLE
Add ad-hoc client-driven sequencing of patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Pixelblaze v2.10 and above send out broadcast UDP packets that are used for disc
 
 Firestorm UI
 =========
-The UI will show all unique pattern names on the network, and selecting a name will activate it on all Pixelblazes that have that pattern name.
+The UI will show all unique pattern names on the network, and selecting a name will launch it on all Pixelblazes that have that pattern name. Launching a pattern will create a new client-driven sequence containing that single pattern. A pattern can be added to the current sequence by clicking the Add button to the right of its name. Once added, an icon will appear to the right of a pattern indicating whether it is the currently running pattern or part of the current sequence. To clear the current sequence, click a pattern name (which will create a new sequence that does not change unless additional patterns are added).
 
 Firestorm API
 =========

--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,7 @@
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
     <link rel="stylesheet" href="bootstrap.min.css">
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.2/css/all.css" integrity="sha384-fnmOCqbTlWIlj8LyTjo7mOUStjsKC4pOpQbqyi7RrhN7udi9RwhKkMHpvLbHG9Sr" crossorigin="anonymous">
 
     <title>Pixelblaze Firestorm</title>
   </head>

--- a/src/PatternView.js
+++ b/src/PatternView.js
@@ -1,0 +1,55 @@
+import React, {Component} from 'react'
+import _ from 'lodash'
+
+class PatternView extends Component {
+
+  render() {
+    const { pattern, status } = this.props
+
+    const renderStatusElement = () => {
+      if (status === 'running') {
+        return <i class="fas fa-play" title="Running now"></i>
+      }
+      if (status === 'sequenced') {
+        return <i class="fas fa-clock" title="In current sequence"></i>
+      }
+      return (
+        <a href="#" onClick={this._handleAddClick}>
+          <i class="fas fa-plus" title="Add to sequence"></i>
+        </a>
+      )
+    }
+
+    return (
+      <div class="row">
+        <div class="col">
+          <a
+            key={pattern.name}
+            href="#"
+            className="list-group-item"
+            onClick={this._handlePatternClick}
+          >
+            <h5>{pattern.name}</h5>
+            <em>
+              <small>{_.map(pattern.pixelblazes, 'name').join(', ')}</small>
+            </em>
+          </a>
+        </div>
+        <div class="col-1">
+          {renderStatusElement()}
+        </div>
+      </div>
+    )
+  }
+
+  _handlePatternClick = (evt) => {
+    this.props.handlePatternClick(evt, this.props.pattern)
+  }
+
+  _handleAddClick = (evt) => {
+    this.props.handleAddClick(evt, this.props.pattern)
+  }
+
+}
+
+export default PatternView


### PR DESCRIPTION
This adds the ability to create sequences on-the-fly. When a pattern is playing, it is part of a sequence that can be added to by clicking the `Add` button (plus sign) to the right of another pattern. Currently, the pattern will change every 15 seconds (assuming more than one pattern is in the sequence). Simply click a pattern name to clear the current sequence and go back to just displaying a single pattern (i.e. a sequence of one pattern that never changes).