### PR TITLE
fix(add_enable_all_disable_all_buttons): this PR adds enable and disable all patterns to the UI to quickly manage all patterns if desired.

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -27,6 +27,10 @@
   padding: 2rem 0rem;
 }
 
+.btn-playlist-bulk {
+  margin-left: 10px;
+}
+
 /* !importants below override many combos of .active and :active */
 .btn-playlist-add {
   outline: none ! important;


### PR DESCRIPTION
The UI on the page loads if nothing is enabled, `DisableAll` is disabled, and `EnableAll` is enabled.
<img width="1491" alt="Screen Shot 2023-04-18 at 4 16 33 PM" src="https://user-images.githubusercontent.com/4196377/232908896-22c2d164-63c6-4f39-91bd-450501e91b95.png">

When the `EnableAll` button is pushed, we show a spinner (this is useful when there is a persistent store on the backend in another PR in this repo.) so that users do not get trigger-happy. The implementation of this spinner is a little hacky. React lifecycles are opinionated on how it re-renders the UI for performance optimization... we trick it by setting a timeout and using the timeout callback. 
<img width="1680" alt="Screen Shot 2023-04-18 at 4 17 30 PM" src="https://user-images.githubusercontent.com/4196377/232909054-f367d740-c2c4-4f34-8bea-8874252e82f9.png">

This is the UI when the page is loaded, and all patterns are enabled. Note the `Enable All` button is disabled, and the `Disable All` button is activated. This is so the user doesn't add the same patterns to the same playlist, preventing accidental duplicates. 
<img width="1602" alt="Screen Shot 2023-04-18 at 4 29 30 PM" src="https://user-images.githubusercontent.com/4196377/232909492-ae8a897f-9bc4-4a84-b158-c8190a483aa3.png">

This is the result of a user clicking on `Disable All`. Note the `Enable All` button is activated, and the `Disable All` button is disabled. The UI reflects nothing is in the current playlist, and the local storage also shows `[]`.
<img width="1510" alt="Screen Shot 2023-04-18 at 4 17 02 PM" src="https://user-images.githubusercontent.com/4196377/232909413-05562617-214e-4dd6-a4e5-d7ed2ddcf99e.png">


This PR resolves https://github.com/simap/Firestorm/issues/45
