### PR TITLE
fix(add_brightness_slider): Adds brightness slider for PBs in network based on PB implementation.

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -42,3 +42,25 @@
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }
 }
+
+.navbrightness {
+  white-space: nowrap;
+}
+
+.navbrightness label {
+  font-size: 170%;
+  margin: 4px 6px;
+  float: left;
+}
+
+#brightness {
+  padding: initial;
+}
+
+.navbrightness input {
+  width: 10em;
+  display: inline-block;
+  border: none;
+  height: 1em;
+  margin-right: 1em;
+}


### PR DESCRIPTION
This PR is based on the implementation in the PB interface, which adds the already familiar brightness slider to the FS UI, with tooltips!
<img width="1030" alt="Screen Shot 2023-04-18 at 11 02 49 PM" src="https://user-images.githubusercontent.com/4196377/232964042-1901b6a9-4649-4f9e-88d1-0b3c925a81d8.png">


using lodash there is a small delay so we don't spam the PBs with messages by moving the slider around. 

```
yarn run v1.22.19
$ node server
listening on 3001
> Pixelblaze Discovery Server listening on 0.0.0.0: 1889
connected to 10.0.0.35
sending to 10225758 at 10.0.0.35 {"getConfig":true,"listPrograms":true,"sendUpdates":false}
connected to 10.0.0.34
sending to 16573876 at 10.0.0.34 {"getConfig":true,"listPrograms":true,"sendUpdates":false}
sending to 10225758 at 10.0.0.35 {"brightness":0.445}
sending to 16573876 at 10.0.0.34 {"brightness":0.445}
sending to 10225758 at 10.0.0.35 {"brightness":0.145}
sending to 16573876 at 10.0.0.34 {"brightness":0.145}
sending to 10225758 at 10.0.0.35 {"activeProgramId":"9YNBonyhXfyFjpYzJ"}
sending to 16573876 at 10.0.0.34 {"activeProgramId":"9YNBonyhXfyFjpYzJ"}
sending to 10225758 at 10.0.0.35 {"brightness":0.325}
sending to 16573876 at 10.0.0.34 {"brightness":0.325}
sending to 10225758 at 10.0.0.35 {"brightness":0.07}
sending to 16573876 at 10.0.0.34 {"brightness":0.07}
sending to 10225758 at 10.0.0.35 {"brightness":0.21}
sending to 16573876 at 10.0.0.34 {"brightness":0.21}
sending to 10225758 at 10.0.0.35 {"brightness":0.125}
sending to 16573876 at 10.0.0.34 {"brightness":0.125}
sending to 10225758 at 10.0.0.35 {"brightness":0.105}
sending to 16573876 at 10.0.0.34 {"brightness":0.105}
sending to 10225758 at 10.0.0.35 {"brightness":0.225}
sending to 16573876 at 10.0.0.34 {"brightness":0.225}
```

This PR resolves https://github.com/simap/Firestorm/issues/46

Since we store brightness levels in localstoraged, based on whats in master currently. When https://github.com/simap/Firestorm/pull/44 is finally merged in we will need to update this to store the brightness level in the db backend also. 